### PR TITLE
Remove taggable notifications module as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     "require": {
         "silverstripe/framework": "^5",
         "league/html-to-markdown": "^5",
-        "spatie/schema-org": "^3.5",
-        "nswdpc/silverstripe-taggable-notifications": "^1"
+        "spatie/schema-org": "^3.5"
     },
     "suggest": {
         "ext-xml": "Use DOMDocument to process HTML documents",


### PR DESCRIPTION
## Changes

+ Remove taggable notifications module as a requirement, as it is not required for this module to function